### PR TITLE
Improve Disclaimer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ in IntelliJ IDEA.
 
 <!-- Plugin description -->
 > **Note**
-> This product is not officially supported by Dynatrace
+> This product is a community-driven open-source plugin, helping users write and execute DQL statements within JetBrains IDEs.
+> It's not officially supported by Dynatrace, please report any errors directly via [GitHub Issues](https://github.com/dynatrace-oss/intellij-idea-dql/issues).
 
 This is an *unofficial* plugin offering tools for effective writing of DQL files. It offers similar functionality
 to the Dynatrace Notebooks, but can work fully locally.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>pl.thedeem.dql</id>
     <name>Dynatrace Query Language</name>
-    <vendor url="https://www.dynatrace.com">(unofficial) Dynatrace</vendor>
+    <vendor url="https://github.com/dynatrace-oss">Dynatrace OSS (community driven)</vendor>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.java</depends>


### PR DESCRIPTION
As we publish this under the Dynatrace namespace at IntelliJ, I suggest to rephrase the disclaimer slightly.
In addition, changing the vendor to `Dynatrace OSS (community driven)`, to distinguish this project from fully supported product/plugins.