### PR TITLE
Bugfix: Fixing an invalid DPL parse behaviour when using nested group or regex

### DIFF
--- a/src/main/grammar/dpl.bnf
+++ b/src/main/grammar/dpl.bnf
@@ -309,5 +309,5 @@ lookaround ::= NEGATION? (PLA | PLB) {
     mixin="pl.thedeem.intellij.dpl.psi.elements.impl.LookaroundElementImpl"
 }
 
-private recover_configuration_content ::= !(IDENTIFIER|OR|R_PAREN)
+private recover_configuration_content ::= !(IDENTIFIER|OR|R_PAREN|L_PAREN|L_BRACE|L_BRACKET)
 private recover_alternative_content ::= !(OR|R_PAREN)


### PR DESCRIPTION
It was taken as a configuration block, making it fail with an invalid character

```dpl
BLANK ('s3://' ([^/]+ '/')):file_name
```