### PR TITLE
Fixing timezone issues when executing DQL queries & generating the current timestamp

### DIFF
--- a/src/main/java/pl/thedeem/intellij/common/sdk/model/DQLExecutePayload.java
+++ b/src/main/java/pl/thedeem/intellij/common/sdk/model/DQLExecutePayload.java
@@ -9,6 +9,7 @@ public class DQLExecutePayload {
     String defaultTimeframeStart;
     Long maxResultBytes;
     Long maxResultRecords;
+    String timezone;
     String query;
 
     public DQLExecutePayload(String query) {
@@ -61,5 +62,13 @@ public class DQLExecutePayload {
 
     public void setQuery(String query) {
         this.query = query;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 }

--- a/src/main/java/pl/thedeem/intellij/dql/components/execution/DQLMetadataPanel.java
+++ b/src/main/java/pl/thedeem/intellij/dql/components/execution/DQLMetadataPanel.java
@@ -12,12 +12,12 @@ import pl.thedeem.intellij.dql.DQLUtil;
 
 import javax.swing.*;
 import java.awt.*;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 public class DQLMetadataPanel extends JPanel {
-    public DQLMetadataPanel(DQLResult.DQLGrailMetadata metadata, @NotNull LocalDateTime executionTime) {
+    public DQLMetadataPanel(DQLResult.DQLGrailMetadata metadata, @NotNull ZonedDateTime executionTime) {
         setLayout(new BorderLayout());
         List<MetadataRow> records = List.of(
                 new MetadataRow(DQLBundle.message("components.queryDetails.values.executionMoment"), executionTime.format(DQLUtil.DQL_DATE_FORMATTER)),

--- a/src/main/java/pl/thedeem/intellij/dql/editor/DQLInjectionLineMakerProvider.java
+++ b/src/main/java/pl/thedeem/intellij/dql/editor/DQLInjectionLineMakerProvider.java
@@ -1,4 +1,4 @@
-package pl.thedeem.intellij.dql.components.editor;
+package pl.thedeem.intellij.dql.editor;
 
 import com.intellij.execution.lineMarker.RunLineMarkerContributor;
 import com.intellij.lang.injection.InjectedLanguageManager;

--- a/src/main/java/pl/thedeem/intellij/dql/editor/DQLMissingTenantNotificationProvider.java
+++ b/src/main/java/pl/thedeem/intellij/dql/editor/DQLMissingTenantNotificationProvider.java
@@ -1,4 +1,4 @@
-package pl.thedeem.intellij.dql.components.editor;
+package pl.thedeem.intellij.dql.editor;
 
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.options.ShowSettingsUtil;

--- a/src/main/java/pl/thedeem/intellij/dql/editor/DQLToolbarProvider.java
+++ b/src/main/java/pl/thedeem/intellij/dql/editor/DQLToolbarProvider.java
@@ -1,4 +1,4 @@
-package pl.thedeem.intellij.dql.components.editor;
+package pl.thedeem.intellij.dql.editor;
 
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.ActionManager;

--- a/src/main/java/pl/thedeem/intellij/dql/executing/DQLExecutionService.java
+++ b/src/main/java/pl/thedeem/intellij/dql/executing/DQLExecutionService.java
@@ -38,7 +38,9 @@ import pl.thedeem.intellij.dql.settings.tenants.DynatraceTenantsService;
 
 import javax.swing.*;
 import java.awt.*;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +60,7 @@ public class DQLExecutionService implements DQLManagedService<QueryConfiguration
     private final AtomicReference<Boolean> loading = new AtomicReference<>(false);
     private final AtomicReference<Exception> errored = new AtomicReference<>(null);
 
-    private LocalDateTime executionTime;
+    private ZonedDateTime executionTime;
     private String requestToken;
     private DQLPollResponse result;
     private String executionId;
@@ -78,7 +80,7 @@ public class DQLExecutionService implements DQLManagedService<QueryConfiguration
 
     @Override
     public void startExecution(@NotNull QueryConfiguration params) {
-        this.executionTime = LocalDateTime.now();
+        this.executionTime = Instant.now().atZone(ZoneId.systemDefault());
         this.configuration = params;
         if (params.query() == null) {
             updatePanel(new DQLExecutionErrorPanel(DQLBundle.message("services.executeDQL.errors.invalidPayload")));
@@ -199,7 +201,7 @@ public class DQLExecutionService implements DQLManagedService<QueryConfiguration
         return result != null ? result.getResult() : null;
     }
 
-    public @NotNull LocalDateTime getExecutionTime() {
+    public @NotNull ZonedDateTime getExecutionTime() {
         return executionTime;
     }
 
@@ -332,6 +334,7 @@ public class DQLExecutionService implements DQLManagedService<QueryConfiguration
         result.setDefaultScanLimitGbytes(configuration.defaultScanLimit());
         result.setMaxResultBytes(configuration.maxResultBytes());
         result.setMaxResultRecords(configuration.maxResultRecords());
+        result.setTimezone(ZoneId.systemDefault().getId());
         return result;
     }
 

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLMetadataVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLMetadataVirtualFile.java
@@ -6,12 +6,12 @@ import pl.thedeem.intellij.common.sdk.model.DQLResult;
 import pl.thedeem.intellij.dql.components.execution.DQLMetadataPanel;
 
 import javax.swing.*;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class DQLMetadataVirtualFile extends DQLVirtualFile<DQLResult.DQLGrailMetadata> {
-    private final LocalDateTime executionTime;
+    private final ZonedDateTime executionTime;
 
-    public DQLMetadataVirtualFile(@NotNull String name, @NotNull DQLResult.DQLGrailMetadata content, @NotNull LocalDateTime executionTime) {
+    public DQLMetadataVirtualFile(@NotNull String name, @NotNull DQLResult.DQLGrailMetadata content, @NotNull ZonedDateTime executionTime) {
         super(name, content);
         this.executionTime = executionTime;
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -301,10 +301,10 @@
 
         <fileEditorProvider implementation="pl.thedeem.intellij.dql.fileProviders.DQLFileEditorProvider"/>
         <editorNotificationProvider
-                implementation="pl.thedeem.intellij.dql.components.editor.DQLMissingTenantNotificationProvider"/>
-        <editorNotificationProvider implementation="pl.thedeem.intellij.dql.components.editor.DQLToolbarProvider"/>
+                implementation="pl.thedeem.intellij.dql.editor.DQLMissingTenantNotificationProvider"/>
+        <editorNotificationProvider implementation="pl.thedeem.intellij.dql.editor.DQLToolbarProvider"/>
         <runLineMarkerContributor language=""
-                                  implementationClass="pl.thedeem.intellij.dql.components.editor.DQLInjectionLineMakerProvider"/>
+                                  implementationClass="pl.thedeem.intellij.dql.editor.DQLInjectionLineMakerProvider"/>
         <!-- endregion -->
         <!-- region DPL -->
         <fileType name="DPL"


### PR DESCRIPTION
The user now haves some flexibility when defining timestamps.