### PR TITLE
Fixed deprecated ReadAction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug fixes
+
+- Replaced deprecated `ReadAction.compute(ThrowableComputable)` usage in DQL live verification code
+
 ## [1.9.0] - 2026-05-26
 
 ### Features
@@ -51,17 +55,20 @@
      max_oom_kills = max(dt.kubernetes.container.oom_kills, default: 0, rollup: sum)
    }
    ```
+
 - `summarize` command will now validate if the `aggregation` parameter contains a valid aggregation function.
 - aggregations are now properly validated within nested expressions, for example:
 
   ```dqlpart
   summarize mbytes = sum(bytes) / 1024 / 1024
   ```
+
 - `join` conditions now support recursive `[]` accessors for `left` and `right` fields, for example:
 
   ```dqlexpr
   left[k8s.pod.uid] == right[objectRef][uid]
   ```
+
 - Much better support for the `alias` parameters - added conflicts detection with assignment expressions and multiple
   `alias` definitions for the same field.
 - Supporting negative values for the DQL time alignment operator, for example: `-1d@d`
@@ -390,18 +397,33 @@
     `null` types.
 
 [Unreleased]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.9.0...HEAD
+
 [1.9.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.8.1...1.9.0
+
 [1.8.1]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.8.0...1.8.1
+
 [1.8.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.7.0...1.8.0
+
 [1.7.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.6.0...1.7.0
+
 [1.6.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.5.0...1.6.0
+
 [1.5.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.4.0...1.5.0
+
 [1.4.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.3.0...1.4.0
+
 [1.3.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.2.0...1.3.0
+
 [1.2.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.1.0...1.2.0
+
 [1.1.0]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.0.4...1.1.0
+
 [1.0.4]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.0.3...1.0.4
+
 [1.0.3]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.0.2...1.0.3
+
 [1.0.2]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.0.1...1.0.2
+
 [1.0.1]: https://github.com/dynatrace-oss/intellij-idea-dql/compare/1.0.0...1.0.1
+
 [1.0.0]: https://github.com/dynatrace-oss/intellij-idea-dql/commits/1.0.0

--- a/src/main/java/pl/thedeem/intellij/dql/inspections/external/DQLVerificationAnnotator.java
+++ b/src/main/java/pl/thedeem/intellij/dql/inspections/external/DQLVerificationAnnotator.java
@@ -49,9 +49,9 @@ public class DQLVerificationAnnotator extends ExternalAnnotator<DQLVerificationA
         DynatraceRestService rest = DynatraceRestService.getInstance(project);
         DynatraceTenant tenant = tenantsService.findTenant(configuration.tenant());
         if (tenant != null) {
-            List<DQLVariablesService.VariableDefinition> variables = ReadAction.compute(
-                    () -> DQLVariablesService.getInstance(project).getDefinedVariables(input.file)
-            );
+            List<DQLVariablesService.VariableDefinition> variables = ReadAction
+                    .nonBlocking(() -> DQLVariablesService.getInstance(project).getDefinedVariables(input.file))
+                    .executeSynchronously();
             DQLQueryParserService.ParseResult parseResult = WriteCommandAction.runWriteCommandAction(
                     project,
                     (Computable<DQLQueryParserService.ParseResult>) () -> parser.getSubstitutedQuery(input.file, variables)


### PR DESCRIPTION
Dynatrace Query Language 1.9.0 uses deprecated API, which may be removed in future releases leading to binary and source code incompatibilities

Deprecated method usage (1)
ReadAction.compute(ThrowableComputable) (1)