### PR TITLE
Removing JetBrains internal API usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [1.9.0] - 2026-05-26
-
 ### Bug fixes
 
 - Removing JetBrains internal API usages
+
+## [1.9.0] - 2026-05-26
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [1.9.0] - 2026-05-26
 
+### Bug fixes
+
+- Removing JetBrains internal API usages
+
 ### Features
 
 - DQL autocompletion now supports bucket names, tabular files, metric keys, and SmartScape entities

--- a/src/main/java/pl/thedeem/intellij/dql/actions/CreateNewDQLFileAction.java
+++ b/src/main/java/pl/thedeem/intellij/dql/actions/CreateNewDQLFileAction.java
@@ -2,7 +2,6 @@ package pl.thedeem.intellij.dql.actions;
 
 import com.intellij.ide.actions.CreateElementActionBase;
 import com.intellij.ide.actions.CreateFileAction;
-import com.intellij.lang.LangBundle;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.DialogWrapper;
@@ -84,7 +83,7 @@ public class CreateNewDQLFileAction extends CreateFileAction {
                 return new ValidationInfo(DQLBundle.message("action.DQL.NewDQLFile.form.validation.alreadyExists"), fileNameField);
             }
             if (!validator.checkInput(fullName) || !validator.canClose(fullName)) {
-                String errorMessage = validator instanceof InputValidatorEx ? ((InputValidatorEx) validator).getErrorText(name) : LangBundle.message("incorrect.name");
+                String errorMessage = validator instanceof InputValidatorEx ? ((InputValidatorEx) validator).getErrorText(name) : DQLBundle.message("action.DQL.NewDQLFile.form.validation.invalidName");
                 return new ValidationInfo(
                         Objects.requireNonNullElseGet(
                                 errorMessage,

--- a/src/main/resources/messages/DQLBundle.properties
+++ b/src/main/resources/messages/DQLBundle.properties
@@ -346,6 +346,7 @@ action.DQL.NewDQLFile.form.validation.nameEmpty=File name cannot be empty
 action.DQL.NewDQLFile.form.validation.invalidCharacters=File name contains invalid characters
 action.DQL.NewDQLFile.form.validation.alreadyExists=A file with this name already exists
 action.DQL.NewDQLFile.form.validation.unknownError=An unknown error occurred while validating the file name
+action.DQL.NewDQLFile.form.validation.invalidName=Incorrect file name
 action.DQL.NewDQLFile.description=Creating Dynatrace file
 action.DQL.ToggleDQLExecutionToolbar.text=Toggle DQL Toolbar Visibility
 action.DQL.ToggleDQLExecutionToolbar.description=Show or hide the toolbar for DQL query execution


### PR DESCRIPTION
Internal API is private and must not be used outside of the IntelliJ Platform itself. Please proceed with the next steps described in this article:

```
LangBundle.message(String, Object[])
```