### PR TITLE
Using JetBrains native components for displaying DQLs and JSONs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Features
+
+- The plugin now uses JetBrains-native code editors for embedded DQLs & JSONs (like the DQL results panel) or Run
+  Configuration. This makes the JSON/DQL code use all JetBrains features like code folding, or proper syntax
+  highlighting.
+
 ### Bug fixes
 
 - Removing JetBrains internal API usages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Features
 
-- The plugin now uses JetBrains-native code editors for embedded DQLs & JSONs (like the DQL results panel) or Run
-  Configuration. This makes the JSON/DQL code use all JetBrains features like code folding, or proper syntax
-  highlighting.
+- The plugin now uses JetBrains-native code editors for embedded DQLs & JSONs (like the DQL results panel).
+  This makes the JSON/DQL code use all JetBrains features like code folding, or proper syntax highlighting.
 
 ### Bug fixes
 

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
@@ -42,7 +41,6 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
         this.fileExtension = languageFileType != null ? languageFileType.getDefaultExtension() : "txt";
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
-        Disposer.register(project, this);
     }
 
     public void showResult(@NotNull Callable<String> content) {

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -1,46 +1,52 @@
 package pl.thedeem.intellij.common.components;
 
-import com.intellij.codeInsight.folding.CodeFoldingManager;
 import com.intellij.lang.Language;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiDocumentManager;
-import com.intellij.ui.EditorTextField;
-import com.intellij.util.concurrency.AppExecutorUtil;
+import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import org.jetbrains.annotations.NotNull;
-import pl.thedeem.intellij.common.IntelliJUtils;
 import pl.thedeem.intellij.dql.DQLBundle;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
 
 public class FormattedLanguageText extends BorderLayoutPanel implements Disposable {
     private final LoadingPanel processIcon;
-    private final EditorTextField editorField;
-    private volatile Future<?> pendingFoldingTask;
+    private final TextEditor textEditor;
 
     public FormattedLanguageText(@NotNull Language language, @NotNull Project project, boolean isViewer) {
         withBorder(JBUI.Borders.empty()).andTransparent();
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
-        editorField = IntelliJUtils.createEditorPanel(project, language, isViewer);
-        addToCenter(editorField);
-        editorField.setVisible(false);
+
+        LanguageFileType languageFileType = language.getAssociatedFileType();
+        FileType fileType = languageFileType != null ? languageFileType : PlainTextFileType.INSTANCE;
+        LightVirtualFile virtualFile = new LightVirtualFile("result." + fileType.getDefaultExtension(), fileType, "");
+
+        textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, virtualFile);
+        if (isViewer) {
+            ((EditorEx) textEditor.getEditor()).setViewer(true);
+        }
+        addToCenter(textEditor.getComponent());
+        textEditor.getComponent().setVisible(false);
     }
 
     public void showResult(@NotNull Callable<String> content) {
-        Project project = editorField.getProject();
-        ProgressManager processManager = ProgressManager.getInstance();
-        processManager.run(new Task.Backgroundable(project, DQLBundle.message("components.preparingView"), true) {
+        Project project = textEditor.getEditor().getProject();
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, DQLBundle.message("components.preparingView"), true) {
             private String resultText;
 
             @Override
@@ -55,37 +61,19 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
 
             @Override
             public void onSuccess() {
-                if (project.isDisposed()) {
+                if (project == null || project.isDisposed()) {
                     return;
                 }
-
                 WriteCommandAction.runWriteCommandAction(project, () -> {
-                    editorField.setText(Objects.requireNonNullElse(resultText, ""));
-                    setEditorFieldVisible();
-                });
-
-                PsiDocumentManager.getInstance(project).performLaterWhenAllCommitted(() -> {
-                    if (editorField.getEditor() == null) {
-                        return;
-                    }
-                    pendingFoldingTask = ReadAction.nonBlocking(() -> {
-                                if (editorField.getEditor() != null) {
-                                    return CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editorField.getEditor(), true);
-                                }
-                                return null;
-                            })
-                            .finishOnUiThread(ModalityState.any(), runnable -> {
-                                if (runnable != null) {
-                                    runnable.run();
-                                }
-                            }).submit(AppExecutorUtil.getAppExecutorService());
+                    textEditor.getEditor().getDocument().setText(StringUtil.convertLineSeparators(Objects.requireNonNullElse(resultText, "")));
+                    setEditorVisible();
                 });
             }
         });
     }
 
-    private void setEditorFieldVisible() {
-        editorField.setVisible(true);
+    private void setEditorVisible() {
+        textEditor.getComponent().setVisible(true);
         processIcon.dispose();
         processIcon.setVisible(false);
         revalidate();
@@ -93,14 +81,12 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
     }
 
     public @NotNull String getText() {
-        return editorField.getText();
+        return textEditor.getEditor().getDocument().getText();
     }
 
     @Override
     public void dispose() {
-        if (pendingFoldingTask != null) {
-            pendingFoldingTask.cancel(true);
-        }
         processIcon.dispose();
+        TextEditorProvider.getInstance().disposeEditor(textEditor);
     }
 }

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
@@ -41,6 +42,7 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
         this.fileExtension = languageFileType != null ? languageFileType.getDefaultExtension() : "txt";
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
+        Disposer.register(project, this);
     }
 
     public void showResult(@NotNull Callable<String> content) {

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -1,12 +1,15 @@
 package pl.thedeem.intellij.common.components;
 
+import com.intellij.codeInsight.folding.CodeFoldingManager;
 import com.intellij.lang.Language;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.ex.EditorEx;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.fileEditor.TextEditor;
-import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
@@ -14,6 +17,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
@@ -25,10 +29,12 @@ import java.util.concurrent.Callable;
 
 public class FormattedLanguageText extends BorderLayoutPanel implements Disposable {
     private final LoadingPanel processIcon;
-    private final TextEditor textEditor;
+    private final Project project;
+    private final Editor editor;
 
     public FormattedLanguageText(@NotNull Language language, @NotNull Project project, boolean isViewer) {
         withBorder(JBUI.Borders.empty()).andTransparent();
+        this.project = project;
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
 
@@ -36,16 +42,18 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
         FileType fileType = languageFileType != null ? languageFileType : PlainTextFileType.INSTANCE;
         LightVirtualFile virtualFile = new LightVirtualFile("result." + fileType.getDefaultExtension(), fileType, "");
 
-        textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, virtualFile);
-        if (isViewer) {
-            ((EditorEx) textEditor.getEditor()).setViewer(true);
-        }
-        addToCenter(textEditor.getComponent());
-        textEditor.getComponent().setVisible(false);
+        Document document = Objects.requireNonNull(FileDocumentManager.getInstance().getDocument(virtualFile));
+        editor = EditorFactory.getInstance().createEditor(document, project, fileType, isViewer);
+        EditorEx editorEx = (EditorEx) editor;
+        editorEx.setFile(virtualFile);
+        editorEx.getSettings().setFoldingOutlineShown(true);
+        editorEx.getFoldingModel().setFoldingEnabled(true);
+
+        addToCenter(editor.getComponent());
+        editor.getComponent().setVisible(false);
     }
 
     public void showResult(@NotNull Callable<String> content) {
-        Project project = textEditor.getEditor().getProject();
         ProgressManager.getInstance().run(new Task.Backgroundable(project, DQLBundle.message("components.preparingView"), true) {
             private String resultText;
 
@@ -61,19 +69,22 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
 
             @Override
             public void onSuccess() {
-                if (project == null || project.isDisposed()) {
-                    return;
-                }
+                if (project.isDisposed()) return;
                 WriteCommandAction.runWriteCommandAction(project, () -> {
-                    textEditor.getEditor().getDocument().setText(StringUtil.convertLineSeparators(Objects.requireNonNullElse(resultText, "")));
+                    editor.getDocument().setText(StringUtil.convertLineSeparators(Objects.requireNonNullElse(resultText, "")));
                     setEditorVisible();
+                });
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (!editor.isDisposed()) {
+                        CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
+                    }
                 });
             }
         });
     }
 
     private void setEditorVisible() {
-        textEditor.getComponent().setVisible(true);
+        editor.getComponent().setVisible(true);
         processIcon.dispose();
         processIcon.setVisible(false);
         revalidate();
@@ -81,12 +92,12 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
     }
 
     public @NotNull String getText() {
-        return textEditor.getEditor().getDocument().getText();
+        return editor.getDocument().getText();
     }
 
     @Override
     public void dispose() {
         processIcon.dispose();
-        TextEditorProvider.getInstance().disposeEditor(textEditor);
+        EditorFactory.getInstance().releaseEditor(editor);
     }
 }

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -5,15 +5,15 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
-import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.LanguageFileType;
-import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import org.jetbrains.annotations.NotNull;
@@ -26,16 +26,18 @@ import java.util.concurrent.Callable;
 public class FormattedLanguageText extends BorderLayoutPanel implements Disposable {
     private final LoadingPanel processIcon;
     private final Project project;
-    private final FileType fileType;
+    private final Language language;
+    private final String fileExtension;
     private final boolean isViewer;
     private @Nullable TextEditor currentEditor;
 
     public FormattedLanguageText(@NotNull Language language, @NotNull Project project, boolean isViewer) {
         withBorder(JBUI.Borders.empty()).andTransparent();
         this.project = project;
+        this.language = language;
         this.isViewer = isViewer;
         LanguageFileType languageFileType = language.getAssociatedFileType();
-        this.fileType = languageFileType != null ? languageFileType : PlainTextFileType.INSTANCE;
+        this.fileExtension = languageFileType != null ? languageFileType.getDefaultExtension() : "txt";
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
     }
@@ -61,9 +63,13 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
 
                 disposeCurrentEditor();
 
-                LightVirtualFile displayFile = new LightVirtualFile("result." + fileType.getDefaultExtension(), fileType, text);
-                displayFile.setWritable(false);
-                TextEditor textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, displayFile);
+                PsiFile psiFile = PsiFileFactory.getInstance(project)
+                        .createFileFromText("result." + fileExtension, language, text);
+                VirtualFile vf = psiFile.getVirtualFile();
+                if (vf == null) {
+                    return;
+                }
+                TextEditor textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, vf);
                 if (isViewer) {
                     ((EditorEx) textEditor.getEditor()).setViewer(true);
                 }

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -1,15 +1,10 @@
 package pl.thedeem.intellij.common.components;
 
-import com.intellij.codeInsight.folding.CodeFoldingManager;
 import com.intellij.lang.Language;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.WriteCommandAction;
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.ex.EditorEx;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
@@ -22,6 +17,7 @@ import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pl.thedeem.intellij.dql.DQLBundle;
 
 import java.util.Objects;
@@ -30,27 +26,18 @@ import java.util.concurrent.Callable;
 public class FormattedLanguageText extends BorderLayoutPanel implements Disposable {
     private final LoadingPanel processIcon;
     private final Project project;
-    private final Editor editor;
+    private final FileType fileType;
+    private final boolean isViewer;
+    private @Nullable TextEditor currentEditor;
 
     public FormattedLanguageText(@NotNull Language language, @NotNull Project project, boolean isViewer) {
         withBorder(JBUI.Borders.empty()).andTransparent();
         this.project = project;
+        this.isViewer = isViewer;
+        LanguageFileType languageFileType = language.getAssociatedFileType();
+        this.fileType = languageFileType != null ? languageFileType : PlainTextFileType.INSTANCE;
         processIcon = new LoadingPanel(DQLBundle.message("components.preparingView"));
         addToCenter(processIcon);
-
-        LanguageFileType languageFileType = language.getAssociatedFileType();
-        FileType fileType = languageFileType != null ? languageFileType : PlainTextFileType.INSTANCE;
-        LightVirtualFile virtualFile = new LightVirtualFile("result." + fileType.getDefaultExtension(), fileType, "");
-
-        Document document = Objects.requireNonNull(FileDocumentManager.getInstance().getDocument(virtualFile));
-        editor = EditorFactory.getInstance().createEditor(document, project, fileType, isViewer);
-        EditorEx editorEx = (EditorEx) editor;
-        editorEx.setFile(virtualFile);
-        editorEx.getSettings().setFoldingOutlineShown(true);
-        editorEx.getFoldingModel().setFoldingEnabled(true);
-
-        addToCenter(editor.getComponent());
-        editor.getComponent().setVisible(false);
     }
 
     public void showResult(@NotNull Callable<String> content) {
@@ -70,34 +57,42 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
             @Override
             public void onSuccess() {
                 if (project.isDisposed()) return;
-                WriteCommandAction.runWriteCommandAction(project, () -> {
-                    editor.getDocument().setText(StringUtil.convertLineSeparators(Objects.requireNonNullElse(resultText, "")));
-                    setEditorVisible();
-                });
-                ApplicationManager.getApplication().invokeLater(() -> {
-                    if (!editor.isDisposed()) {
-                        CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
-                    }
-                });
+                String text = StringUtil.convertLineSeparators(Objects.requireNonNullElse(resultText, ""));
+
+                disposeCurrentEditor();
+
+                LightVirtualFile displayFile = new LightVirtualFile("result." + fileType.getDefaultExtension(), fileType, text);
+                displayFile.setWritable(false);
+                TextEditor textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, displayFile);
+                if (isViewer) {
+                    ((EditorEx) textEditor.getEditor()).setViewer(true);
+                }
+                currentEditor = textEditor;
+
+                addToCenter(textEditor.getComponent());
+                processIcon.dispose();
+                processIcon.setVisible(false);
+                revalidate();
+                repaint();
             }
         });
     }
 
-    private void setEditorVisible() {
-        editor.getComponent().setVisible(true);
-        processIcon.dispose();
-        processIcon.setVisible(false);
-        revalidate();
-        repaint();
+    private void disposeCurrentEditor() {
+        if (currentEditor != null) {
+            remove(currentEditor.getComponent());
+            TextEditorProvider.getInstance().disposeEditor(currentEditor);
+            currentEditor = null;
+        }
     }
 
     public @NotNull String getText() {
-        return editor.getDocument().getText();
+        return currentEditor != null ? currentEditor.getEditor().getDocument().getText() : "";
     }
 
     @Override
     public void dispose() {
         processIcon.dispose();
-        EditorFactory.getInstance().releaseEditor(editor);
+        disposeCurrentEditor();
     }
 }

--- a/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
+++ b/src/main/java/pl/thedeem/intellij/common/components/FormattedLanguageText.java
@@ -3,6 +3,7 @@ package pl.thedeem.intellij.common.components;
 import com.intellij.lang.Language;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.fileTypes.LanguageFileType;
@@ -69,14 +70,18 @@ public class FormattedLanguageText extends BorderLayoutPanel implements Disposab
                 if (vf == null) {
                     return;
                 }
-                TextEditor textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, vf);
-                if (isViewer) {
-                    ((EditorEx) textEditor.getEditor()).setViewer(true);
+
+                FileEditor fileEditor = TextEditorProvider.getInstance().createEditor(project, vf);
+                if (!(fileEditor instanceof TextEditor textEditor)) {
+                    fileEditor.dispose();
+                    return;
+                }
+                if (isViewer && textEditor.getEditor() instanceof EditorEx editorEx) {
+                    editorEx.setViewer(true);
                 }
                 currentEditor = textEditor;
 
                 addToCenter(textEditor.getComponent());
-                processIcon.dispose();
                 processIcon.setVisible(false);
                 revalidate();
                 repaint();

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
@@ -1,7 +1,8 @@
 package pl.thedeem.intellij.dql.fileProviders;
 
 import com.intellij.codeInsight.folding.CodeFoldingManager;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
@@ -10,7 +11,9 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 import pl.thedeem.intellij.dql.DQLFileType;
 
@@ -59,11 +62,17 @@ public abstract class DQLVirtualFile<T> extends LightVirtualFile {
         editorEx.setFile(displayFile);
         editorEx.getSettings().setFoldingOutlineShown(true);
         editorEx.getFoldingModel().setFoldingEnabled(true);
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (!editor.isDisposed()) {
-                CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
-            }
-        });
+        PsiDocumentManager.getInstance(project).performLaterWhenAllCommitted(() ->
+                ReadAction.nonBlocking(() -> {
+                            if (!editor.isDisposed()) {
+                                return CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
+                            }
+                            return null;
+                        })
+                        .finishOnUiThread(ModalityState.any(), runnable -> {
+                            if (runnable != null) runnable.run();
+                        })
+                        .submit(AppExecutorUtil.getAppExecutorService()));
         return this.editor.getComponent();
     }
 

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
@@ -1,20 +1,20 @@
 package pl.thedeem.intellij.dql.fileProviders;
 
-import com.intellij.codeInsight.folding.CodeFoldingManager;
-import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.ReadAction;
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.lang.Language;
 import com.intellij.openapi.editor.ex.EditorEx;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiDocumentManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
 import com.intellij.testFramework.LightVirtualFile;
-import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pl.thedeem.intellij.dql.DQLFileType;
 
 import javax.swing.*;
@@ -22,13 +22,13 @@ import java.util.Objects;
 
 public abstract class DQLVirtualFile<T> extends LightVirtualFile {
     protected final T content;
-    protected Editor editor = null;
+    private @Nullable TextEditor textEditor = null;
 
     public DQLVirtualFile(@NotNull String name, @NotNull T content) {
         super(name, DQLFileType.INSTANCE, content.toString());
         this.content = content;
     }
-    
+
     @Override
     public boolean isWritable() {
         return false;
@@ -48,32 +48,21 @@ public abstract class DQLVirtualFile<T> extends LightVirtualFile {
     }
 
     public void dispose() {
-        if (editor != null) {
-            EditorFactory.getInstance().releaseEditor(editor);
+        if (textEditor != null) {
+            TextEditorProvider.getInstance().disposeEditor(textEditor);
+            textEditor = null;
         }
     }
 
     public @NotNull JComponent createComponent(@NotNull Project project) {
-        LightVirtualFile displayFile = new LightVirtualFile(getName(), getBaseFileType(), getDocumentContent());
-        displayFile.setWritable(false);
-        Document document = Objects.requireNonNull(FileDocumentManager.getInstance().getDocument(displayFile));
-        this.editor = EditorFactory.getInstance().createEditor(document, project, getBaseFileType(), true);
-        EditorEx editorEx = (EditorEx) this.editor;
-        editorEx.setFile(displayFile);
-        editorEx.getSettings().setFoldingOutlineShown(true);
-        editorEx.getFoldingModel().setFoldingEnabled(true);
-        PsiDocumentManager.getInstance(project).performLaterWhenAllCommitted(() ->
-                ReadAction.nonBlocking(() -> {
-                            if (!editor.isDisposed()) {
-                                return CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
-                            }
-                            return null;
-                        })
-                        .finishOnUiThread(ModalityState.any(), runnable -> {
-                            if (runnable != null) runnable.run();
-                        })
-                        .submit(AppExecutorUtil.getAppExecutorService()));
-        return this.editor.getComponent();
+        FileType baseFileType = getBaseFileType();
+        Language language = baseFileType instanceof LanguageFileType lft ? lft.getLanguage() : PlainTextLanguage.INSTANCE;
+        PsiFile psiFile = PsiFileFactory.getInstance(project)
+                .createFileFromText(getName(), language, getDocumentContent());
+        VirtualFile vf = Objects.requireNonNull(psiFile.getVirtualFile());
+        this.textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, vf);
+        ((EditorEx) this.textEditor.getEditor()).setViewer(true);
+        return this.textEditor.getComponent();
     }
 
     protected @NotNull FileType getBaseFileType() {

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
@@ -1,8 +1,12 @@
 package pl.thedeem.intellij.dql.fileProviders;
 
+import com.intellij.codeInsight.folding.CodeFoldingManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.project.Project;
@@ -47,9 +51,19 @@ public abstract class DQLVirtualFile<T> extends LightVirtualFile {
     }
 
     public @NotNull JComponent createComponent(@NotNull Project project) {
-        Document document = EditorFactory.getInstance().createDocument(getDocumentContent());
-        document.setReadOnly(true);
-        this.editor = EditorFactory.getInstance().createEditor(document, project, getBaseFileType(), false);
+        LightVirtualFile displayFile = new LightVirtualFile(getName(), getBaseFileType(), getDocumentContent());
+        displayFile.setWritable(false);
+        Document document = Objects.requireNonNull(FileDocumentManager.getInstance().getDocument(displayFile));
+        this.editor = EditorFactory.getInstance().createEditor(document, project, getBaseFileType(), true);
+        EditorEx editorEx = (EditorEx) this.editor;
+        editorEx.setFile(displayFile);
+        editorEx.getSettings().setFoldingOutlineShown(true);
+        editorEx.getFoldingModel().setFoldingEnabled(true);
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!editor.isDisposed()) {
+                CodeFoldingManager.getInstance(project).updateFoldRegionsAsync(editor, true);
+            }
+        });
         return this.editor.getComponent();
     }
 

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
@@ -2,6 +2,7 @@ package pl.thedeem.intellij.dql.fileProviders;
 
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.fileTypes.FileType;
@@ -13,6 +14,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pl.thedeem.intellij.dql.DQLFileType;
@@ -55,14 +57,27 @@ public abstract class DQLVirtualFile<T> extends LightVirtualFile {
     }
 
     public @NotNull JComponent createComponent(@NotNull Project project) {
+        dispose();
+
         FileType baseFileType = getBaseFileType();
         Language language = baseFileType instanceof LanguageFileType lft ? lft.getLanguage() : PlainTextLanguage.INSTANCE;
         PsiFile psiFile = PsiFileFactory.getInstance(project)
                 .createFileFromText(getName(), language, getDocumentContent());
-        VirtualFile vf = Objects.requireNonNull(psiFile.getVirtualFile());
-        this.textEditor = (TextEditor) TextEditorProvider.getInstance().createEditor(project, vf);
-        ((EditorEx) this.textEditor.getEditor()).setViewer(true);
-        return this.textEditor.getComponent();
+        VirtualFile vf = psiFile.getVirtualFile();
+        if (vf == null) {
+            return JBUI.Panels.simplePanel();
+        }
+
+        FileEditor fileEditor = TextEditorProvider.getInstance().createEditor(project, vf);
+        if (!(fileEditor instanceof TextEditor te)) {
+            fileEditor.dispose();
+            return JBUI.Panels.simplePanel();
+        }
+        if (te.getEditor() instanceof EditorEx editorEx) {
+            editorEx.setViewer(true);
+        }
+        this.textEditor = te;
+        return te.getComponent();
     }
 
     protected @NotNull FileType getBaseFileType() {

--- a/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
+++ b/src/main/java/pl/thedeem/intellij/dql/fileProviders/DQLVirtualFile.java
@@ -74,7 +74,7 @@ public abstract class DQLVirtualFile<T> extends LightVirtualFile {
             return JBUI.Panels.simplePanel();
         }
         if (te.getEditor() instanceof EditorEx editorEx) {
-            editorEx.setViewer(true);
+            editorEx.setViewer(!isWritable());
         }
         this.textEditor = te;
         return te.getComponent();


### PR DESCRIPTION
Instead of using a preconfigured text editor, the plugin now displays code fragments as proper files.