### PR TITLE
Fixing deprecated API usage

### DIFF
--- a/src/main/java/pl/thedeem/intellij/dql/exec/DQLExecutionService.java
+++ b/src/main/java/pl/thedeem/intellij/dql/exec/DQLExecutionService.java
@@ -329,11 +329,12 @@ public class DQLExecutionService implements ManagedService, UiDataProvider {
     }
 
     private @Nullable DQLExecutePayload preparePayload(@NotNull Project project) {
-        String query = ReadAction.compute(() -> resolveQuery(project));
+        String query = ReadAction.nonBlocking(() -> resolveQuery(project)).executeSynchronously();
         if (query == null) {
             return null;
         }
-        List<DQLVariablesService.VariableDefinition> variables = ReadAction.compute(() -> loadVariables(configuration.originalFile(), project));
+        List<DQLVariablesService.VariableDefinition> variables = ReadAction.nonBlocking(
+                () -> loadVariables(configuration.originalFile(), project)).executeSynchronously();
         DQLQueryParserService.ParseResult parsed = WriteCommandAction.runWriteCommandAction(
                 project,
                 (Computable<DQLQueryParserService.ParseResult>) () -> DQLQueryParserService.getInstance().getSubstitutedQuery(query, project, variables));
@@ -405,3 +406,4 @@ public class DQLExecutionService implements ManagedService, UiDataProvider {
         contentPanel.removeAll();
     }
 }
+

--- a/src/main/java/pl/thedeem/intellij/dql/exec/runConfiguration/ExecuteDQLRunConfiguration.java
+++ b/src/main/java/pl/thedeem/intellij/dql/exec/runConfiguration/ExecuteDQLRunConfiguration.java
@@ -124,7 +124,8 @@ public class ExecuteDQLRunConfiguration extends RunConfigurationBase<ExecuteDQLR
         options.setMaxResultBytes(configuration.maxResultBytes());
         options.setMaxResultRecords(configuration.maxResultRecords());
         if (file != null) {
-            options.setDqlQuery(ReadAction.compute(() -> DQLQuerySelectorService.getInstance().getQueryText(file)));
+            String query = ReadAction.nonBlocking(() -> DQLQuerySelectorService.getInstance().getQueryText(file)).executeSynchronously();
+            options.setDqlQuery(query);
         }
     }
 


### PR DESCRIPTION
Deprecated API usages (2):
    #Deprecated method com.intellij.openapi.application.ReadAction.compute(ThrowableComputable) invocation
        Deprecated method com.intellij.openapi.application.ReadAction.compute(com.intellij.openapi.util.ThrowableComputable action) : T is invoked in pl.thedeem.intellij.dql.exec.runConfiguration.ExecuteDQLRunConfiguration.loadFromConfiguration(QueryConfiguration, PsiFile) : void
        Deprecated method com.intellij.openapi.application.ReadAction.compute(com.intellij.openapi.util.ThrowableComputable action) : T is invoked in pl.thedeem.intellij.dql.exec.DQLExecutionService.preparePayload(Project) : DQLExecutePayload