### PR TITLE
Fixing NullPointerException when autocompleting parameters for a func…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug fixes
 
 - Removing JetBrains internal API usages
+- Fixing NullPointerException when autocompleting parameters for a function without any parameters
 
 ## [1.9.0] - 2026-05-26
 

--- a/src/main/java/pl/thedeem/intellij/dql/documentation/providers/DQLFunctionDocumentationProvider.java
+++ b/src/main/java/pl/thedeem/intellij/dql/documentation/providers/DQLFunctionDocumentationProvider.java
@@ -32,7 +32,7 @@ public class DQLFunctionDocumentationProvider extends BaseDocumentationProvider<
             }
             Signature signature = element.getSignature();
             if (signature != null) {
-                if (signature.outputs() != null && !signature.outputs().isEmpty()) {
+                if (!signature.outputs().isEmpty()) {
                     sections.add(buildTitledSection(
                             DQLBundle.message("documentation.function.returnValues"),
                             prepareValuesDescription(signature.outputs(), element.getProject())));

--- a/src/main/java/pl/thedeem/intellij/dql/services/definition/model/Signature.java
+++ b/src/main/java/pl/thedeem/intellij/dql/services/definition/model/Signature.java
@@ -24,11 +24,11 @@ public final class Signature {
     }
 
     public List<Parameter> parameters() {
-        return parameters;
+        return Objects.requireNonNullElseGet(parameters, List::of);
     }
 
     public List<String> outputs() {
-        return outputs;
+        return Objects.requireNonNullElseGet(outputs, List::of);
     }
 
     public Boolean experimental() {
@@ -71,7 +71,9 @@ public final class Signature {
     }
 
     public @NotNull List<Parameter> requiredParameters() {
-        List<Parameter> params = Objects.requireNonNullElse(parameters, List.of());
-        return params.stream().filter(p -> !p.hidden() && Boolean.TRUE.equals(p.required())).toList();
+        return parameters()
+                .stream()
+                .filter(p -> !p.hidden() && Boolean.TRUE.equals(p.required()))
+                .toList();
     }
 }


### PR DESCRIPTION
…tion without any parameters

```
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "pl.thedeem.intellij.dql.services.definition.model.Signature.parameters()" is null
	at pl.thedeem.intellij.dql.completion.engines.DQLFunctionParametersCompletion.autocomplete(DQLFunctionParametersCompletion.java:36)
	at pl.thedeem.intellij.dql.completion.DQLLocalCompletionContributor$2.addCompletions(DQLLocalCompletionContributor.java:21)
	at com.intellij.codeInsight.completion.CompletionProvider.addCompletionVariants(CompletionProvider.java:23)
```